### PR TITLE
Adding Brasero to burnertools

### DIFF
--- a/install/apps/multimedia/burnertools
+++ b/install/apps/multimedia/burnertools
@@ -6,6 +6,7 @@ options+=("k3b" "" off)
 options+=("xfburn" "" off)
 #options+=("xorriso-tcltk" "libisoburn tk kjobwidgets" off)
 options+=("brasero" "" off)
+options+=("gnomebaker" "(AUR)" off)
 
 sel=$(whiptail --backtitle "$apptitle" --title "Burner applications :" --checklist "Choose what you want" --cancel-button "Back" 0 0 0 \
   "${options[@]}" \
@@ -16,6 +17,7 @@ fi
 
 for itm in $sel; do
   case $itm in
+    '"gnomebaker"') aurpkg="$aurpkg $(echo $itm | sed 's/"//g')";;
     '"xorriso-tcltk"') pkg="$pkg libisoburn tk kjobwidgets";;
     *) pkg="$pkg $(echo $itm | sed 's/"//g')";;
   esac

--- a/install/apps/multimedia/burnertools
+++ b/install/apps/multimedia/burnertools
@@ -5,7 +5,7 @@ options=()
 options+=("k3b" "" off)
 options+=("xfburn" "" off)
 #options+=("xorriso-tcltk" "libisoburn tk kjobwidgets" off)
-options+=("gnomebaker" "(AUR)" off)
+options+=("brasero" "" off)
 
 sel=$(whiptail --backtitle "$apptitle" --title "Burner applications :" --checklist "Choose what you want" --cancel-button "Back" 0 0 0 \
   "${options[@]}" \
@@ -16,7 +16,6 @@ fi
 
 for itm in $sel; do
   case $itm in
-    '"gnomebaker"') aurpkg="$aurpkg $(echo $itm | sed 's/"//g')";;
     '"xorriso-tcltk"') pkg="$pkg libisoburn tk kjobwidgets";;
     *) pkg="$pkg $(echo $itm | sed 's/"//g')";;
   esac


### PR DESCRIPTION
Gnomebaker is long dead. Last release was made in 2008. Replacing it by Brasero which is supported.