### PR TITLE
syslog-ng service modification

### DIFF
--- a/install/system/services/menu
+++ b/install/system/services/menu
@@ -66,7 +66,7 @@ for itm in $sel; do
     ;;
     '"syslog-ng"')
       #echo "ForwardToSyslog=yes" >> /etc/systemd/journald.conf
-      systemctl enable syslog-ng
+      systemctl enable syslog-ng@default
     ;;
     '"rsyslog"')
       systemctl enable rsyslog


### PR DESCRIPTION
"Reason: Since syslog-ng-3.12, the systemd unit file is templated and users should start/enable syslog-ng@default.service to get the previous behaviour. (Discuss in Talk:Syslog-ng#)"

Source: https://wiki.archlinux.org/index.php/Syslog-ng#Overview