### PR TITLE
fix dhcpcd typo

### DIFF
--- a/install/system/services/menu
+++ b/install/system/services/menu
@@ -56,7 +56,7 @@ for itm in $sel; do
     '"networkmanager"')
       systemctl disable dhcpcd
       if (svcenable NetworkManager) then
-        svcdisable dhcpd
+        svcdisable dhcpcd
       fi
     ;;
     '"openssh"')


### PR DESCRIPTION
'dhcp' vs 'dhcpd' - the disable service fails due to the typo. sent similar pr for archfi to fix text description for same.